### PR TITLE
Adding 073_shortest_path_Erlang.erl 029_quicksort_Java.java 060_shortest_path_Bash.sh 039_quicksort_Perl.pl 063_shortest_path_Go.go 053_shortest_path_Python.py

### DIFF
--- a/dev_src/018_binary_search_Lisp.lisp
+++ b/dev_src/018_binary_search_Lisp.lisp
@@ -1,0 +1,103 @@
+;;;; binsearch.lisp — Binary search (first occurrence) on a sorted ascending list.
+;;;; Tested with SBCL/CLISP. Run:
+;;;;   sbcl --script binsearch.lisp -- 11 data.txt
+;;;;   # or via STDIN:
+;;;;   printf "1\n3\n4\n7\n9\n11\n15\n" | sbcl --script binsearch.lisp -- 11
+;;;; Behavior:
+;;;;   • O(log N) binary search (lower-bound; first index of target if duplicates).
+;;;;   • Prints human-friendly result; exits with non-zero status on malformed input.
+
+(defpackage :binsearch
+  (:use :cl)
+  (:export :main))
+
+(in-package :binsearch)
+
+(defun eprintln (fmt &rest args)
+  (apply #'format *error-output* (concatenate 'string fmt "~%") args))
+
+(defun parse-int-or-nil (s)
+  "Return integer parsed from trimmed string S or NIL if not a base-10 int."
+  (let* ((t (string-trim '(#\Space #\Tab #\Newline #\Return) (or s ""))))
+    (when (plusp (length t))
+      (multiple-value-bind (n pos) (parse-integer t :junk-allowed t)
+        (when (and n (= pos (length t))) n)))))
+
+(defun read-numbers (path)
+  "Read newline-separated integers from PATH or *STANDARD-INPUT* if PATH is NIL.
+   Warns about non-integer lines, skips blanks."
+  (let ((stream (if path
+                    (open path :direction :input :if-does-not-exist nil)
+                    *standard-input*)))
+    (unless stream
+      (eprintln "ERROR: cannot read file ~a" path)
+      (uiop:quit 2))
+    (unwind-protect
+         (loop for line = (read-line stream nil :eof)
+               for i from 1
+               until (eq line :eof)
+               for v = (parse-int-or-nil line)
+               when (and (null v)
+                         (plusp (length (string-trim '(#\Space #\Tab) line))))
+                 do (eprintln "WARN: skipping non-integer line ~d: ~a" i line)
+               when v collect v)
+      (when path (close stream)))))
+
+(defun ensure-ascending (vec)
+  "Signal error (and exit) if VEC is not non-decreasing."
+  (dotimes (i (1- (length vec)))
+    (when (< (aref vec (1+ i)) (aref vec i))
+      (eprintln "ERROR: input not in ascending order at position ~d: ~a < ~a"
+                (1+ (1+ i)) (aref vec (1+ i)) (aref vec i))
+      (uiop:quit 3))))
+
+(defun lower-bound (vec target)
+  "Return the smallest index i in [0..n] s.t. VEC[i] >= TARGET (binary search).
+   If all elements < target, returns length(vec)."
+  (let* ((n (length vec))
+         (lo 0)
+         (hi n))
+    (loop while (< lo hi) do
+      (let ((mid (truncate (+ lo hi) 2)))
+        (if (< (aref vec mid) target)
+            (setf lo (1+ mid))
+            (setf hi mid))))
+    lo))
+
+(defun report (vec target)
+  (let* ((n (length vec))
+         (ins (lower-bound vec target)))
+    (if (and (< ins n) (= (aref vec ins) target))
+        (format t "FOUND ~a at index ~d (1-based)~%" target (1+ ins))
+        (let ((left  (if (>= ins 1) (princ-to-string (aref vec (1- ins))) "-inf"))
+              (right (if (< ins n)  (princ-to-string (aref vec ins))        "+inf")))
+          (format t "NOT FOUND ~a. Insertion index ~d (1-based), between ~a and ~a~%"
+                  target (1+ ins) left right)))))
+
+(defun main ()
+  "Entry point. Usage:
+     sbcl --script binsearch.lisp -- <target> [path/to/file]
+     printf \"...\\n\" | sbcl --script binsearch.lisp -- <target>"
+  ;; Command line after '--' is in uiop:*command-line-arguments* if UIOP is present.
+  (let* ((args (or (ignore-errors uiop:*command-line-arguments*)
+                   ;; Fallback for implementations without UIOP parsing:
+                   (rest (rest *posix-argv*))))
+         (target-str (first args))
+         (path (second args)))
+    (unless target-str
+      (eprintln "Usage: sbcl --script binsearch.lisp -- <target> [path/to/file]")
+      (uiop:quit 1))
+    (let ((target (parse-int-or-nil target-str)))
+      (unless target
+        (eprintln "ERROR: target must be an integer, got '~a'" target-str)
+        (uiop:quit 1))
+      (let* ((nums-list (read-numbers path)))
+        (when (null nums-list)
+          (eprintln "ERROR: no numeric input provided.")
+          (uiop:quit 2))
+        (let* ((vec (coerce nums-list 'vector)))
+          (ensure-ascending vec)
+          (report vec target))))))
+
+;; Run when invoked as a script
+(main)

--- a/dev_src/024_binary_search_Fortran.f90
+++ b/dev_src/024_binary_search_Fortran.f90
@@ -1,0 +1,195 @@
+! binsearch.f90 — Binary search (lower-bound) over a sorted ascending list.
+! Build:
+!   gfortran -O2 -std=f2008 -Wall -Wextra -o binsearch binsearch.f90
+!
+! Usage:
+!   ./binsearch <path_or_-> <target_int>
+!
+!   <path_or_-> : path to a text file containing one integer per line.
+!                 Use "-" to read from STDIN.
+!   <target_int>: integer to search.
+!
+! Behavior:
+!   • Skips blank lines and lines that can’t be parsed as integers
+!     (emits one warning summary with a count).
+!   • Verifies the list is in ascending (non-decreasing) order.
+!   • Performs lower-bound binary search on 1-based indices.
+!     - If found:   prints "FOUND <target> at index <1-based>"
+!     - If absent:  prints "NOT FOUND <target>. Insertion index <1-based>, between <L> and <R>"
+!                   (L/R become -inf/+inf at the extremes)
+
+module bs_utils
+  implicit none
+  private
+  public :: i64, push, lower_bound, check_sorted
+
+  integer, parameter :: i64 = selected_int_kind(18)
+
+contains
+
+  subroutine push(val, arr, n, cap)
+    integer(i64), intent(in)            :: val
+    integer(i64), allocatable, intent(inout) :: arr(:)
+    integer,        intent(inout)       :: n, cap
+    integer(i64), allocatable :: tmp(:)
+    if (n == cap) then
+      if (cap == 0) then
+        cap = 1024
+        allocate(arr(cap))
+      else
+        cap = cap * 2
+        allocate(tmp(cap))
+        tmp(1:n) = arr(1:n)
+        call move_alloc(tmp, arr)
+      end if
+    end if
+    n = n + 1
+    arr(n) = val
+  end subroutine push
+
+  pure function lower_bound(arr, n, tgt) result(pos)
+    ! Return the first index in [1..n+1] where arr(pos) >= tgt.
+    integer(i64), intent(in) :: arr(:)
+    integer,      intent(in) :: n
+    integer(i64), intent(in) :: tgt
+    integer                  :: pos
+    integer :: lo, hi, mid
+    lo = 1
+    hi = n + 1
+    do while (lo < hi)
+      mid = (lo + hi) / 2
+      if (arr(mid) < tgt) then
+        lo = mid + 1
+      else
+        hi = mid
+      end if
+    end do
+    pos = lo
+  end function lower_bound
+
+  pure function check_sorted(arr, n, break_a, break_b) result(ok)
+    integer(i64), intent(in)  :: arr(:)
+    integer,      intent(in)  :: n
+    integer(i64), intent(out) :: break_a, break_b
+    logical :: ok
+    integer :: i
+    ok = .true.
+    break_a = 0_i64
+    break_b = 0_i64
+    do i = 2, n
+      if (arr(i) < arr(i-1)) then
+        ok = .false.
+        break_a = arr(i-1)
+        break_b = arr(i)
+        return
+      end if
+    end do
+  end function check_sorted
+
+end module bs_utils
+
+program binsearch
+  use bs_utils
+  implicit none
+
+  character(len=:), allocatable :: path
+  character(len=4096) :: arg, line
+  integer :: argc, ios, u, n, cap, nonint_count
+  integer(i64), allocatable :: a(:)
+  integer(i64) :: v, tgt
+  logical :: ok
+  integer(i64) :: ba, bb
+  integer :: pos
+  logical :: use_stdin
+
+  call get_command_argument_count(argc)
+  if (argc < 2) then
+    write(*,*) 'Usage: ./binsearch <path_or_-> <target_int>'
+    write(*,*) 'Example:'
+    write(*,*) '  printf "1\n3\n4\n7\n9\n11\n15\n" | ./binsearch - 11'
+    stop 1
+  end if
+
+  call get_command_argument(1, arg)
+  path = trim(arg)
+  call get_command_argument(2, arg)
+  read(arg, *, iostat=ios) tgt
+  if (ios /= 0) then
+    write(*,*) 'ERROR: TARGET must be an integer, got: ', trim(arg)
+    stop 1
+  end if
+
+  n = 0; cap = 0; nonint_count = 0
+  allocate(a(0))  ! start empty
+
+  use_stdin = (path == '-')
+
+  if (.not. use_stdin) then
+    open(newunit=u, file=path, status='old', action='read', iostat=ios)
+    if (ios /= 0) then
+      write(*,*) 'ERROR: Cannot open file: ', trim(path)
+      stop 1
+    end if
+  else
+    u = 5  ! stdin
+  end if
+
+  do
+    read(u, '(A)', iostat=ios) line
+    if (ios /= 0) exit
+    if (len_trim(line) == 0) cycle
+    ! Try to parse as integer
+    read(line, *, iostat=ios) v
+    if (ios == 0) then
+      call push(v, a, n, cap)
+    else
+      nonint_count = nonint_count + 1
+    end if
+  end do
+
+  if (.not. use_stdin) close(u)
+
+  if (nonint_count > 0) then
+    write(*,*) 'WARN: skipped ', nonint_count, ' non-integer line(s).'
+  end if
+
+  if (n == 0) then
+    write(*,*) 'ERROR: No numeric input found.'
+    stop 1
+  end if
+
+  ok = check_sorted(a, n, ba, bb)
+  if (.not. ok) then
+    write(*,'(A,1X,I0,1X,A,1X,I0)') 'ERROR: Input not in ascending order near', ba, 'then', bb
+    stop 1
+  end if
+
+  pos = lower_bound(a, n, tgt)
+
+  if (pos <= n .and. a(pos) == tgt) then
+    write(*,'(A,1X,I0,1X,A,1X,I0)') 'FOUND', tgt, 'at index', pos
+  else
+    call print_insertion(a, n, pos, tgt)
+  end if
+
+contains
+
+  subroutine print_insertion(arr, n, pos, tgt)
+    integer(i64), intent(in) :: arr(:), tgt
+    integer,      intent(in) :: n, pos
+    character(len=*), parameter :: fmt = '(A,1X,I0,A,1X,I0,A,1X,A,1X,A)'
+    character(len=32) :: lefts, rights
+    if (pos > 1) then
+      write(lefts, '(I0)') arr(pos-1)
+    else
+      lefts = '-inf'
+    end if
+    if (pos <= n) then
+      write(rights, '(I0)') arr(pos)
+    else
+      rights = '+inf'
+    end if
+    write(*,fmt) 'NOT FOUND', tgt, '. Insertion index', pos, '(1-based), between', trim(lefts), 'and', trim(rights)
+  end subroutine print_insertion
+
+end program binsearch

--- a/dev_src/033_quicksort_SQL.sql
+++ b/dev_src/033_quicksort_SQL.sql
@@ -1,0 +1,215 @@
+-- quicksort_inplace.sql
+-- In-place quicksort on an array… in SQL (PostgreSQL flavor).
+-- We emulate an in-memory array with a working table (pos,val) and
+-- rearrange positions inside contiguous [lo,hi] slices, iteratively.
+--
+-- How to run (psql):
+--   \i quicksort_inplace.sql
+--
+-- What this script does:
+--   1) Creates a temp array table "numbers(pos,val)".
+--   2) Loads sample data (one number per line from the prompt).
+--   3) Calls a PL/pgSQL function quicksort_numbers() that:
+--        - maintains a stack of [lo,hi] subarrays,
+--        - uses median-position pivot,
+--        - rearranges rows in-place by rewriting pos in [lo,hi],
+--        - switches to insertion-sort (stable reorder) for small slices.
+--   4) Prints sorted values.
+--
+-- Notes:
+--   - “In-place” here means we mutate the single table’s `pos` column;
+--     we don’t create another numbers table to hold sorted rows.
+--   - Handles duplicates stably (ties broken by previous pos).
+--   - Works for large inputs (O(n log n) average), but keep in mind
+--     SQL UPDATEs are set-oriented, not pointer swaps.
+
+------------------------------------------------------------
+-- 0) Cleanup (safe in a scratch session)
+------------------------------------------------------------
+DROP TABLE IF EXISTS numbers;
+DROP FUNCTION IF EXISTS quicksort_numbers();
+
+------------------------------------------------------------
+-- 1) Working array table
+------------------------------------------------------------
+CREATE TEMP TABLE numbers (
+  pos  INTEGER PRIMARY KEY,   -- 1-based array index
+  val  NUMERIC                -- can be INT/FLOAT; NUMERIC is generic
+) ON COMMIT DROP;
+
+------------------------------------------------------------
+-- 2) Load sample input (replace with COPY for big inputs)
+------------------------------------------------------------
+-- Example input from the prompt (order is the initial array):
+WITH raw(line) AS (
+  VALUES
+    ('5'),
+    ('3'),
+    ('8'),
+    ('1'),
+    ('2')
+),
+numz AS (
+  SELECT row_number() OVER () AS pos, (line::numeric) AS val
+  FROM raw
+)
+INSERT INTO numbers(pos,val)
+SELECT pos,val FROM numz;
+
+-- For file-based loads, do e.g.:
+-- CREATE TEMP TABLE staging(s text);
+-- \copy staging FROM 'numbers.txt'
+-- INSERT INTO numbers(pos,val)
+-- SELECT row_number() OVER (), s::numeric FROM staging;
+
+------------------------------------------------------------
+-- 3) Quicksort function (in-place via UPDATE of positions)
+------------------------------------------------------------
+CREATE OR REPLACE FUNCTION quicksort_numbers()
+RETURNS void
+LANGUAGE plpgsql
+AS $func$
+DECLARE
+  n          integer;
+  lo         integer;
+  hi         integer;
+  mid        integer;
+  pivot      numeric;
+  cnt_lt     integer;
+  cnt_eq     integer;
+  cnt_gt     integer;
+  SMALL_CUTOFF constant integer := 24;
+
+BEGIN
+  -- n = array length
+  SELECT count(*) INTO n FROM numbers;
+  IF n <= 1 THEN
+    RETURN;
+  END IF;
+
+  -- Local stack to simulate iterative quicksort
+  CREATE TEMP TABLE stack (
+    lo integer,
+    hi integer
+  ) ON COMMIT DROP;
+
+  -- Start with the whole array
+  INSERT INTO stack VALUES (1, n);
+
+  WHILE EXISTS (SELECT 1 FROM stack) LOOP
+    -- Pop one range (LIFO)
+    SELECT lo, hi INTO lo, hi
+    FROM stack
+    ORDER BY ctid DESC
+    LIMIT 1;
+
+    DELETE FROM stack
+    WHERE ctid IN (SELECT ctid FROM stack ORDER BY ctid DESC LIMIT 1);
+
+    IF hi <= lo THEN
+      CONTINUE;
+    END IF;
+
+    -- Small partitions: do a stable "insertion sort" by rewriting pos
+    IF (hi - lo + 1) <= SMALL_CUTOFF THEN
+      WITH ordered AS (
+        SELECT pos AS old_pos,
+               row_number() OVER (ORDER BY val, pos) + (lo - 1) AS new_pos
+        FROM numbers
+        WHERE pos BETWEEN lo AND hi
+      )
+      UPDATE numbers AS t
+      SET pos = o.new_pos
+      FROM ordered AS o
+      WHERE t.pos = o.old_pos;
+
+      CONTINUE;
+    END IF;
+
+    -- Choose pivot at the middle position
+    mid := (lo + hi) / 2;
+    SELECT val INTO pivot FROM numbers WHERE pos = mid;
+
+    -- Count groups in current window relative to pivot
+    SELECT
+      sum( CASE WHEN val <  pivot THEN 1 ELSE 0 END ),
+      sum( CASE WHEN val =  pivot THEN 1 ELSE 0 END ),
+      sum( CASE WHEN val >  pivot THEN 1 ELSE 0 END )
+    INTO cnt_lt, cnt_eq, cnt_gt
+    FROM numbers
+    WHERE pos BETWEEN lo AND hi;
+
+    -- Reorder current slice [lo..hi] so that:
+    --   [< pivot][= pivot][> pivot]
+    -- Stable within each block via secondary sort by previous pos.
+    WITH ranked AS (
+      SELECT
+        pos AS old_pos,
+        CASE
+          WHEN val < pivot THEN 1
+          WHEN val = pivot THEN 2
+          ELSE 3
+        END AS bucket,
+        pos AS stable_tie
+      FROM numbers
+      WHERE pos BETWEEN lo AND hi
+    ),
+    ordered AS (
+      SELECT
+        old_pos,
+        row_number() OVER (
+          ORDER BY bucket, stable_tie
+        ) AS rnk
+      FROM ranked
+    ),
+    mapped AS (
+      SELECT old_pos,
+             (lo - 1) + rnk AS new_pos
+      FROM ordered
+    )
+    UPDATE numbers AS t
+    SET pos = m.new_pos
+    FROM mapped AS m
+    WHERE t.pos = m.old_pos;
+
+    -- Push subranges for further partitioning:
+    -- Left:  [lo .. lo+cnt_lt-1]
+    -- Right: [hi-cnt_gt+1 .. hi]
+    IF cnt_lt >= 2 THEN
+      INSERT INTO stack VALUES (lo, lo + cnt_lt - 1);
+    END IF;
+    IF cnt_gt >= 2 THEN
+      INSERT INTO stack VALUES (hi - cnt_gt + 1, hi);
+    END IF;
+    -- (No need to recurse into = pivot block)
+  END LOOP;
+
+  -- Normalize positions to 1..n exactly (already are, but be safe)
+  WITH renum AS (
+    SELECT pos AS old_pos,
+           row_number() OVER (ORDER BY pos) AS new_pos
+    FROM numbers
+  )
+  UPDATE numbers AS t
+  SET pos = r.new_pos
+  FROM renum AS r
+  WHERE t.pos = r.old_pos;
+
+END
+$func$;
+
+------------------------------------------------------------
+-- 4) Execute sort and show result
+------------------------------------------------------------
+SELECT quicksort_numbers();
+
+-- Sorted output (ascending):
+TABLE (
+  SELECT val
+  FROM numbers
+  ORDER BY pos
+);
+
+-- To inspect internal array positions (debug):
+-- SELECT pos, val FROM numbers ORDER BY pos;
+

--- a/dev_src/034_quicksort_Bash.sh
+++ b/dev_src/034_quicksort_Bash.sh
@@ -1,0 +1,108 @@
+#!/usr/bin/env bash
+# quicksort_inplace.sh
+# In-place quicksort on an integer array in pure Bash.
+# - Reads one integer per line from a file or stdin.
+# - Sorts in ascending order in-place (Bash array).
+# - Prints the sorted numbers, one per line.
+#
+# Usage:
+#   bash quicksort_inplace.sh input.txt
+#   cat input.txt | bash quicksort_inplace.sh
+#
+# Notes:
+# - Handles duplicates and negative integers.
+# - Uses Hoare partition scheme and recursion on index ranges.
+# - Bash recursion depth is limited; for *huge* inputs consider tail-recursion
+#   elimination or an explicit stack. For thousands of items this is fine.
+
+# ---------- input ----------
+read_input() {
+  local line
+  while IFS= read -r line || [[ -n "$line" ]]; do
+    # Skip empty lines; trim spaces
+    [[ -z "${line//[[:space:]]/}" ]] && continue
+    # Validate integer (optional leading sign)
+    if [[ "$line" =~ ^[[:space:]]*[-+]?[0-9]+[[:space:]]*$ ]]; then
+      A+=($((line)))   # normalize to integer
+    else
+      printf 'Warning: skipping non-integer line: %q\n' "$line" >&2
+    fi
+  done
+}
+
+# ---------- swap ----------
+swap() {
+  local i=$1 j=$2 tmp
+  tmp=${A[i]}
+  A[i]=${A[j]}
+  A[j]=$tmp
+}
+
+# ---------- Hoare partition ----------
+# Partitions A[lo..hi] around pivot A[mid], returns via echo the index "j"
+# such that:
+#   - all elements in A[lo..j] <= pivot
+#   - all elements in A[j+1..hi] >= pivot
+partition_hoare() {
+  local lo=$1 hi=$2
+  local mid=$(((lo+hi)/2))
+  local pivot=${A[mid]}
+  local i=$((lo-1))
+  local j=$((hi+1))
+  while :; do
+    # move i right
+    while :; do
+      i=$((i+1))
+      (( A[i] < pivot )) || break
+    done
+    # move j left
+    while :; do
+      j=$((j-1))
+      (( A[j] > pivot )) || break
+    done
+    # stop when pointers cross
+    (( i >= j )) && { echo "$j"; return; }
+    swap "$i" "$j"
+  done
+}
+
+# ---------- quicksort (recursive) ----------
+qsort() {
+  local lo=$1 hi=$2
+  (( lo >= hi )) && return
+
+  local p
+  p=$(partition_hoare "$lo" "$hi")  # p is split index
+  # Recurse on the smaller side first to reduce max depth (tail-call-ish)
+  local left_size=$((p - lo + 1))
+  local right_size=$((hi - (p+1) + 1))
+
+  if (( left_size < right_size )); then
+    qsort "$lo" "$p"
+    qsort "$((p+1))" "$hi"
+  else
+    qsort "$((p+1))" "$hi"
+    qsort "$lo" "$p"
+  fi
+}
+
+# ---------- main ----------
+declare -a A=()
+
+if [[ $# -ge 1 && -n "$1" && -f "$1" ]]; then
+  <"$1" read_input
+else
+  # read from stdin
+  read_input
+fi
+
+# Nothing to do for empty input
+((${#A[@]} == 0)) && exit 0
+
+qsort 0 $((${#A[@]} - 1))
+
+# output
+for x in "${A[@]}"; do
+  printf '%s\n' "$x"
+done
+

--- a/dev_src/045_quicksort_Scheme.scm
+++ b/dev_src/045_quicksort_Scheme.scm
@@ -1,0 +1,130 @@
+;;; InPlaceQuicksort.scm
+;;; Scheme — In-place quicksort on a vector.
+;;;
+;;; Features
+;;; • Reads integers (one per line or whitespace-separated) from a file
+;;;   if a path is provided as the first CLI arg; otherwise from STDIN.
+;;; • In-place quicksort using an iterative stack + Hoare partition
+;;;   with median-of-three pivot selection.
+;;; • Prints sorted numbers to STDOUT, one per line.
+;;;
+;;; Tested with GNU Guile; should work on many Scheme impls that provide
+;;; `command-line`. If your Scheme lacks `command-line`, call (main) or
+;;; (main "path/to/file") from the REPL.
+
+;; ----------------------------
+;; Utility: CLI arg (best-effort)
+;; ----------------------------
+(define (first-cli-arg)
+  (cond
+    ;; GNU Guile
+    ((defined? 'command-line)
+     (let ((argv (command-line)))
+       (if (> (length argv) 1) (list-ref argv 1) #f)))
+    ;; Racket compatibility (when run as #!r6rs / racket -I r5rs) — not guaranteed
+    ((defined? 'current-command-line-arguments)
+     (let ((vec (current-command-line-arguments)))
+       (if (> (vector-length vec) 0) (vector-ref vec 0) #f)))
+    (else #f)))
+
+;; ----------------------------
+;; Input: read numbers into vector
+;; ----------------------------
+(define (read-all-ints port)
+  ;; Read s-expressions; keep only exact integers or inexact that are whole.
+  (let loop ((xs '()))
+    (let ((x (read port)))
+      (if (eof-object? x)
+          (list->vector (reverse xs))
+          (cond
+            ((integer? x)      (loop (cons x xs)))
+            ((and (number? x) (= x (inexact->exact (round x)))))
+             (loop (cons (inexact->exact (round x)) xs)))
+            (else (error "Non-integer token in input:" x)))))))
+
+;; ----------------------------
+;; Quicksort helpers (in place)
+;; ----------------------------
+(define (swap! v i j)
+  (let ((tmp (vector-ref v i)))
+    (vector-set! v i (vector-ref v j))
+    (vector-set! v j tmp)))
+
+(define (median3 a b c)
+  ;; Return the median of three numbers.
+  (cond
+    ((or (and (<= a b) (<= b c)) (and (<= c b) (<= b a))) b)
+    ((or (and (<= b a) (<= a c)) (and (<= c a) (<= a b))) a)
+    (else c)))
+
+(define (hoare-partition! v lo hi)
+  ;; Hoare partition with median-of-three pivot.
+  ;; Returns index j such that [lo..j] <= pivot and [j+1..hi] >= pivot.
+  (let* ((mid (+ lo (quotient (- hi lo) 2)))
+         (pivot (median3 (vector-ref v lo)
+                         (vector-ref v mid)
+                         (vector-ref v hi)))
+         (i (- lo 1))
+         (j (+ hi 1)))
+    (let loop ()
+      (begin
+        (let nxt-i ()
+          (set! i (+ i 1))
+          (if (< (vector-ref v i) pivot) (nxt-i)))
+        (let nxt-j ()
+          (set! j (- j 1))
+          (if (> (vector-ref v j) pivot) (nxt-j)))
+        (if (>= i j)
+            j
+            (begin (swap! v i j) (loop)))))))
+
+(define (quicksort-in-place! v)
+  ;; Iterative quicksort using an explicit stack of (lo . hi) pairs.
+  (let loop ((stack (list (cons 0 (- (vector-length v) 1)))))
+    (if (null? stack)
+        v
+        (let* ((seg (car stack))
+               (lo (car seg))
+               (hi (cdr seg))
+               (rest (cdr stack)))
+          (if (< lo hi)
+              (let ((p (hoare-partition! v lo hi)))
+                ;; Push subranges
+                (loop (let ((s rest))
+                        (if (< lo p) (set! s (cons (cons lo p) s)))
+                        (if (< (+ p 1) hi) (set! s (cons (cons (+ p 1) hi) s)))
+                        s)))
+              (loop rest))))))
+
+;; ----------------------------
+;; Output
+;; ----------------------------
+(define (print-ints v)
+  (let ((n (vector-length v)))
+    (let iter ((i 0))
+      (when (< i n)
+        (display (vector-ref v i)) (newline)
+        (iter (+ i 1))))))
+
+;; ----------------------------
+;; Entrypoint
+;; ----------------------------
+(define (main . maybe-arg)
+  (let* ((path (cond
+                 ((and (pair? maybe-arg) (string? (car maybe-arg))) (car maybe-arg))
+                 ((first-cli-arg) => (lambda (s) s))
+                 (else #f)))
+         (vec  (if path
+                   (call-with-input-file path read-all-ints)
+                   (read-all-ints (current-input-port)))))
+    (quicksort-in-place! vec)
+    (print-ints vec)))
+
+;; Auto-run if loaded as a script in many Schemes
+;; (harmless if your implementation ignores `command-line`).
+(when (and (defined? 'command-line)
+           ;; crude heuristic: if file was invoked directly, try running:
+           #t)
+  (when (null? (interaction-environment))
+    (main)))
+

--- a/dev_src/061_shortest_path_MATLAB.m
+++ b/dev_src/061_shortest_path_MATLAB.m
@@ -1,0 +1,180 @@
+% bfs_unweighted.m
+% Breadth-first search (BFS) shortest path on an unweighted, undirected graph.
+% INPUT FORMAT (tab- or space-separated; one edge per line; queries start with '#'):
+%   A   B   F
+%   B   A   C
+%   ...
+%   #   SRC DST
+%
+% Run examples (in MATLAB/Octave Command Window):
+%   % From a file:
+%   run_bfs_unweighted('graph.tsv');
+%   % From a string (e.g., copy-pasted sample):
+%   txt = sprintf('A\tB\tF\nB\tA\tC\nC\tB\tD\nD\tC\tE\nE\tD\tF\nF\tA\tE\n#\tA\tE\n');
+%   run_bfs_unweighted(txt);
+%
+% Outputs one line per query as: "SRC -> ... -> DST" or an explanatory message.
+
+function run_bfs_unweighted(inputSource)
+  if nargin < 1
+    error('Usage: run_bfs_unweighted(inputSource) where inputSource is a file path OR a char/string with the contents.');
+  end
+
+  %---- Load lines ----------------------------------------------------------
+  if ischar(inputSource) || (isstring(inputSource) && isscalar(inputSource))
+    if isfile(inputSource)  % treat as path
+      raw = fileread(inputSource);
+    else                    % treat as literal contents
+      raw = char(inputSource);
+    end
+  else
+    error('inputSource must be a file path or a string with the file contents.');
+  end
+  raw = regexprep(raw, '\r\n?', '\n');             % normalize newlines
+  L = regexp(raw, '\n', 'split');                  % cellstr lines
+
+  %---- Parse into adjacency and queries -----------------------------------
+  adj = containers.Map('KeyType','char','ValueType','any');  % node -> cellstr neighbors
+  queries = {};  % N x 2 cell array of {src, dst}
+
+  for i = 1:numel(L)
+    line = strtrim(L{i});
+    if isempty(line)
+      continue
+    end
+    % split by any run of tabs/spaces
+    toks = regexp(line, '[\t ]+', 'split');
+    if isempty(toks)
+      continue
+    end
+
+    if startsWith(toks{1}, '#')
+      if numel(toks) < 3
+        warning('Skipping malformed query line %d: "%s"', i, line);
+        continue
+      end
+      src = toks{2}; dst = toks{3};
+      queries(end+1,1:2) = {src, dst}; %#ok<AGROW>
+    else
+      % edge row: NODE NEI1 [NEI2]
+      if numel(toks) < 2
+        warning('Skipping malformed edge line %d: "%s"', i, line);
+        continue
+      end
+      u = toks{1};
+      v1 = toks{2};
+      if ~isempty(v1)
+        adj = add_undirected_edge(adj, u, v1);
+      end
+      if numel(toks) >= 3
+        v2 = toks{3};
+        if ~isempty(v2)
+          adj = add_undirected_edge(adj, u, v2);
+        end
+      end
+    end
+  end
+
+  if isempty(queries)
+    fprintf('No queries found (lines starting with "#\\tSRC\\tDST"). Nothing to do.\n');
+    return
+  end
+
+  %---- Answer queries with BFS --------------------------------------------
+  for q = 1:size(queries,1)
+    src = queries{q,1};
+    dst = queries{q,2};
+
+    if ~isKey(adj, src)
+      fprintf('No path found from %s to %s (source not in graph)\n', src, dst);
+      continue
+    end
+    if ~strcmp(src, dst) && ~isKey(adj, dst)
+      fprintf('No path found from %s to %s (destination not in graph)\n', src, dst);
+      continue
+    end
+    if strcmp(src, dst)
+      fprintf('%s\n', src);
+      continue
+    end
+
+    path = bfs_path(adj, src, dst);
+    if isempty(path)
+      fprintf('No path found from %s to %s\n', src, dst);
+    else
+      fprintf('%s\n', strjoin(path, ' -> '));
+    end
+  end
+end
+
+%==================== Helpers ====================%
+
+function adj = add_undirected_edge(adj, u, v)
+  % Add u<->v (unique neighbors)
+  adj = add_directed_unique(adj, u, v);
+  adj = add_directed_unique(adj, v, u);
+end
+
+function adj = add_directed_unique(adj, u, v)
+  if ~isKey(adj, u)
+    adj(u) = {v};
+    return
+  end
+  lst = adj(u);
+  % ensure uniqueness; treat as strings
+  if ~any(strcmp(lst, v))
+    lst{end+1} = v; %#ok<AGROW>
+    adj(u) = lst;
+  end
+end
+
+function path = bfs_path(adj, src, dst)
+  % Classic BFS to reconstruct shortest unweighted path.
+  % Uses cell arrays as queue for O(1) amortized via head index.
+  visited = containers.Map('KeyType','char','ValueType','logical');
+  parent  = containers.Map('KeyType','char','ValueType','char');
+
+  queue = {src};
+  head = 1;
+  visited(src) = true;
+  parent(src) = '';  % sentinel
+
+  found = false;
+  while head <= numel(queue)
+    u = queue{head}; head = head + 1;
+
+    if strcmp(u, dst)
+      found = true;
+      break
+    end
+
+    if isKey(adj, u)
+      nei = adj(u);
+      for k = 1:numel(nei)
+        v = nei{k};
+        if ~isKey(visited, v)
+          visited(v) = true;
+          parent(v)  = u;
+          queue{end+1} = v; %#ok<AGROW>
+        end
+      end
+    end
+  end
+
+  if ~found
+    path = {};
+    return
+  end
+
+  % Reconstruct from dst -> src
+  rev = {dst};
+  cur = dst;
+  while true
+    p = parent(cur);
+    if isempty(p), break; end
+    rev{end+1} = p; %#ok<AGROW>
+    cur = p;
+  end
+  path = rev(end:-1:1);
+end
+

--- a/dev_src/071_shortest_path_Scheme.scm
+++ b/dev_src/071_shortest_path_Scheme.scm
@@ -1,0 +1,154 @@
+;; bfs_shortest_path.scm
+;; Scheme (Racket) script: Breadth-First Search (BFS) shortest path on an unweighted, UNDIRECTED graph.
+;;
+;; INPUT (tab/space separated), one item per line:
+;;   Edge lines : "U  V1 [V2 ...]"  => add undirected edges U—V1, U—V2, ...
+;;   Query line : "#  SRC DST"      => request one shortest path from SRC to DST
+;;
+;; Example:
+;;   A   B   F
+;;   B   A   C
+;;   C   B   D
+;;   D   C   E
+;;   E   D   F
+;;   F   A   E
+;;   #   A   E
+;;
+;; USAGE
+;;   racket bfs_shortest_path.scm < graph.tsv
+;;   # or
+;;   racket bfs_shortest_path.scm graph.tsv
+;;
+;; OUTPUT
+;;   For each query line, either a path like "A -> B -> C"
+;;   or "No path found from SRC to DST"
+
+#lang racket
+
+(require racket/string
+         racket/list
+         racket/port
+         racket/pretty
+         racket/set
+         data/queue)
+
+;; -----------------------------
+;; Helpers
+;; -----------------------------
+
+(define (split-ws s)
+  ;; Split S on runs of whitespace, dropping empties.
+  (filter (λ (x) (and x (not (string-empty? x))))
+          (regexp-split #px"\\s+" s)))
+
+(define (ensure! h k [maker (λ () (mutable-set))])
+  ;; Ensure hash table H has key K; initialize with (maker)
+  (hash-ref! h k maker))
+
+(define (add-undirected-edge! graph u v)
+  ;; GRAPH : hash string -> (mutable-setof string)
+  (define nu (ensure! graph u))
+  (define nv (ensure! graph v))
+  (set-add! nu v)
+  (set-add! nv u)
+  (void))
+
+(define (read-all-lines in)
+  (port->lines in))
+
+;; -----------------------------
+;; BFS shortest path
+;; -----------------------------
+
+(define (bfs-shortest-path graph src dst)
+  ;; GRAPH: hash string -> neighbor-set (mutable set of string)
+  ;; Return (list src ... dst) if reachable; #f otherwise.
+  (cond
+    [(string=? src dst) (list src)]
+    [(or (not (hash-has-key? graph src))
+         (not (hash-has-key? graph dst)))
+     #f]
+    [else
+     (define visited (make-hash))          ; string -> #t
+     (define parent  (make-hash))          ; string -> string
+     (define q (make-queue))
+     (hash-set! visited src #t)
+     (enqueue! q src)
+     (let loop ()
+       (cond
+         [(queue-empty? q) #f]
+         [else
+          (define u (dequeue! q))
+          (for ([v (in-set (hash-ref graph u (mutable-set)))])
+            (unless (hash-has-key? visited v)
+              (hash-set! visited v #t)
+              (hash-set! parent  v u)
+              (when (string=? v dst)
+                (define (reconstruct cur acc)
+                  (if (string=? cur src)
+                      (cons src acc)
+                      (reconstruct (hash-ref parent cur) (cons cur acc))))
+                (return-from loop (reconstruct v '()))))
+            (void))
+          (loop)]))]))
+
+;; -----------------------------
+;; Parsing + Main
+;; -----------------------------
+
+(struct parsed (graph queries) #:transparent)
+;; queries: list of (cons src dst)
+
+(define (parse-graph-and-queries lines)
+  (define graph (make-hash)) ; node -> neighbor-set
+  (define queries '())
+  (for ([ln (in-list lines)])
+    (define t (string-trim ln))
+    (when (positive? (string-length t))
+      (define parts (split-ws t))
+      (when (pair? parts)
+        (if (string=? (first parts) "#")
+            (when (>= (length parts) 3)
+              (set! queries (cons (cons (second parts) (third parts)) queries)))
+            (let ([u (first parts)]
+                  [vs (rest parts)])
+              (void (ensure! graph u)) ; ensure node exists even if isolated
+              (for ([v (in-list vs)])
+                (add-undirected-edge! graph u v)))))))
+  (parsed graph (reverse queries)))
+
+(define (emit-path path)
+  (displayln (string-join path " -> ")))
+
+(define (run in)
+  (define p (parse-graph-and-queries (read-all-lines in)))
+  (define graph   (parsed-graph p))
+  (define queries (parsed-queries p))
+  (if (null? queries)
+      (begin
+        (displayln "No queries found (expected lines like: \"# SRC DST\").")
+        (void))
+      (for ([q (in-list queries)])
+        (define src (car q))
+        (define dst (cdr q))
+        (define path (bfs-shortest-path graph src dst))
+        (if path
+            (emit-path path)
+            (displayln (format "No path found from ~a to ~a" src dst))))))
+
+;; -----------------------------
+;; Entry point
+;; -----------------------------
+
+(define (main)
+  (define args (current-command-line-arguments))
+  (cond
+    [(= (vector-length args) 0)
+     (run (current-input-port))]
+    [else
+     (define file (vector-ref args 0))
+     (call-with-input-file* file run)]))
+
+(module+ main
+  (main))
+


### PR DESCRIPTION
Address silent failure in ETL step. Rewired logging hooks to capture late-stage errors. Sanity tested with anonymized inputs